### PR TITLE
プロフィールと回答が改行されないバグを修正

### DIFF
--- a/src/components/SelfIntroduction.vue
+++ b/src/components/SelfIntroduction.vue
@@ -27,6 +27,10 @@ export default {
   font-size: 1.1em;
 }
 
+.item-self-intro__text {
+  white-space: pre-wrap;
+}
+
 .item-self-intro__text--center {
   text-align: center;
 }

--- a/src/mains/PostDetails.vue
+++ b/src/mains/PostDetails.vue
@@ -393,6 +393,7 @@ a {
 .block-content__text {
   min-height: 50px;
   margin: 30px 0;
+  white-space: pre-wrap;
 }
 
 /* 物件情報 */
@@ -493,7 +494,7 @@ a {
 }
 
 .form-answer__textarea {
-  height: 100px;
+  height: 200px;
   padding: 10px;
   border-color: silver;
   border-radius: 3px;


### PR DESCRIPTION
## Issue
#53 

## 概要
プロフィールと回答を表示する部分で改行が適用されていなかったので修正

## 動作確認内容
- プロフィール
1. プロフィール編集画面で自己紹介に改行を含めて保存
2. マイページのプロフィールの欄に改行が適用されていることを確認

- 回答
1. 投稿詳細画面にて改行ありの回答を入力
2. 質問詳細画面下部に表示されている回答に改行が含まれていることを確認