### PR TITLE
プロフィールの値にnullが代入されるバグを修正

### DIFF
--- a/src/mains/EditProfileForm.vue
+++ b/src/mains/EditProfileForm.vue
@@ -98,6 +98,10 @@ export default {
         params = new FormData();
         // 送信データを作成
         Object.entries(this.newData).forEach(([key, value]) => {
+          // 自己紹介の値がnullの場合は空文字列をセット
+          if (key === "self_introduction" && !value) {
+            value = "";
+          }
           params.append(key, value);
         });
       }


### PR DESCRIPTION
## Issue
#55 

## 概要
プロフィール編集時に自己紹介の値がnullという文字列で登録されてしまうバグを修正

以下詳細
- プロフィール編集画面でform-dataを使うと自己紹介(self_introduction)の値がnullになることがあるので、その場合は再度空文字列を入力するように変更

## 動作確認内容
プロフィール編集画面にて画像を変更し内容を保存すると、マイページに表示されるプロフィールが変更されていないこと（nullが入力されていないこと）を確認
