### PR TITLE
データが重複したときのバリデーション機能を追加

### DIFF
--- a/src/components/AuthInfo.vue
+++ b/src/components/AuthInfo.vue
@@ -10,6 +10,10 @@
         v-model="userEmail"
       />
     </div>
+    <ValidationMessage
+      :messages="emailMessages"
+      v-show="emailMessages.length"
+    />
     <button class="container-auth-info__btn" @click="changeEmail">保存</button>
     <router-link
       :to="{ name: 'changePassword' }"
@@ -20,10 +24,16 @@
 </template>
 
 <script>
+import ValidationMessage from "@/components/ValidationMessage";
+
 export default {
+  components: {
+    ValidationMessage,
+  },
   data() {
     return {
       userEmail: "",
+      emailMessages: [],
     };
   },
   created() {
@@ -32,6 +42,8 @@ export default {
   },
   methods: {
     changeEmail() {
+      this.emailMessages = [];
+
       // データはオブジェクトで送信
       this.$store
         .dispatch("auth/editAuthInfo", { email: this.userEmail })
@@ -40,6 +52,17 @@ export default {
             name: "userView",
             params: { id: this.$store.getters["auth/userId"] },
           }); // マイページへ
+        })
+        .catch((err) => {
+          if (err.response.data.message === "Duplicate") {
+            err.response.data.fields.forEach((field) => {
+              if (field === "email") {
+                this.emailMessages.push(
+                  "このメールアドレスは既に使われています。"
+                );
+              }
+            });
+          }
         });
     },
   },

--- a/src/components/SelfIntroduction.vue
+++ b/src/components/SelfIntroduction.vue
@@ -1,9 +1,7 @@
 <template>
   <!-- 自己紹介 -->
   <div class="item-self-intro">
-    <p class="item-self-intro__text" v-if="selfIntroduction">
-      {{ selfIntroduction }}
-    </p>
+    <p class="item-self-intro__text" v-if="selfIntroduction">{{ selfIntroduction }}</p>
     <p class="item-self-intro__text item-self-intro__text--center" v-else>
       自己紹介はありません
     </p>

--- a/src/mains/SignUpForm.vue
+++ b/src/mains/SignUpForm.vue
@@ -143,9 +143,22 @@ export default {
           // ホームページへ
           this.$router.replace("/");
         })
-        .catch(() => {
+        .catch((err) => {
           // 登録ボタンを有効化
           buttonElement.disabled = false;
+          if (err.response.data.message === "Duplicate") {
+            err.response.data.fields.forEach((field) => {
+              if (field === "username") {
+                this.usernameMessage.push(
+                  "このユーザー名は既に使われています。"
+                );
+              } else if (field === "email") {
+                this.emailMessage.push(
+                  "このメールアドレスは既に使われています。"
+                );
+              }
+            });
+          }
         });
     },
     validate() {


### PR DESCRIPTION
## Issue
#57 

## 概要
ユーザーのデータが重複したときにバリデーションメッセージを表示する機能を作成

以下詳細
- ユーザー新規登録時のusernameとemail
- プロフィール編集時のusername
- 認証情報変更時のemail

## 動作確認内容
新規登録画面
1. usernameまたはemailに重複している値を入力してボタンを押す
2. 入力欄の下にバリデーションメッセージが表示されることを確認

プロフィール編集画面
1. usernameに重複した値を入力して保存ボタンを押す
2. 入力欄の下にバリデーションメッセージが表示されていることを確認

マイページ
1. 右のサイドメニューから[設定] > [認証情報]をクリック
2. Emailの編集画面が表示されたら、重複したEmailを入力する
3. 保存ボタンを押すとEmailの入力欄の下にバリデーションメッセージが表示されることを確認