### PR TITLE
GoogleMapのリンクを質問詳細画面に追加

### DIFF
--- a/src/mains/PostDetails.vue
+++ b/src/mains/PostDetails.vue
@@ -14,6 +14,16 @@
             {{ postalCodeData(post.address) }}
             <span>{{ addressData(post.address) }}</span>
           </p>
+          <a
+            class="item-property__link-map"
+            :href="
+              'https://maps.google.co.jp/maps/search/' +
+              this.addressData(post.address)
+            "
+            target="_blank"
+            rel="noopener noreferrer"
+            >地図を表示</a
+          >
         </div>
         <p class="block-content__updated-at">{{ post.updatedAt }}</p>
         <!-- 内容 -->
@@ -402,6 +412,10 @@ a {
 }
 
 /* 物件情報 */
+.item-property {
+  font-size: 0.9em;
+}
+
 .item-property__title {
   margin: 20px 0 0;
 }
@@ -410,7 +424,6 @@ a {
   display: flex;
   flex-wrap: wrap;
   margin: 0;
-  font-size: 0.9em;
 }
 
 /* 投稿日時 */


### PR DESCRIPTION
## Issue
#63 

## 概要
質問詳細画面に物件のGoogleMapのリンクを貼り付けた

以下詳細
- 物件の郵便番号を除く所在地の情報をリンクに載せて物件の場所が地図でわかるようにした

## 動作確認内容
質問詳細画面上部の地図を表示というリンクをクリックして、新規タブに地図が表示されていることを確認