### PR TITLE
【質問詳細画面】回答の投稿者表示部分にメソッドを追加

### DIFF
--- a/src/mains/PostDetails.vue
+++ b/src/mains/PostDetails.vue
@@ -46,7 +46,10 @@
             >お気に入り解除</a
           >
           <!-- 投稿者 -->
-          <div class="item-bottom__author" @click="moveToUserPage">
+          <div
+            class="item-bottom__author"
+            @click="moveToUserPage(post.user.id)"
+          >
             <!-- アイコン -->
             <div class="block-icon">
               <img
@@ -128,7 +131,10 @@
               @click.prevent="dislike(answer.id)"
               >いいね {{ answer.likedBy.length }}</a
             >
-            <div class="item-bottom__author">
+            <div
+              class="item-bottom__author"
+              @click="moveToUserPage(answer.user.id)"
+            >
               <div class="block-icon">
                 <img class="block-icon__img" :src="answer.user.icon_url" />
               </div>
@@ -264,10 +270,10 @@ export default {
       });
     },
     // 投稿者のページへ移動
-    moveToUserPage() {
+    moveToUserPage(id) {
       this.$router.push({
         name: "userView",
-        params: { id: this.post.user.id },
+        params: { id },
       });
     },
     // 回答を投稿する


### PR DESCRIPTION
## Issue
#74 

## 概要
質問詳細画面の回答者表示部分をクリックしてもユーザーのページに飛べなかったので機能を修正した

以下詳細
- moveToUserPageメソッドの引数にユーザーのidを設定
- 回答者表示部分にmoveToUserPageメソッドを追加

## 動作確認内容
回答者部分をクリックして回答者のページに移動できれば確認完了
